### PR TITLE
[integration] Adds prometheus-server for gathering fluent-bit metrics

### DIFF
--- a/integration/tests/elasticsearch/setup.tf
+++ b/integration/tests/elasticsearch/setup.tf
@@ -4,6 +4,10 @@ provider "helm" {
   }
 }
 
+variable "prometheus-config" {
+  type = string
+}
+
 variable "fluent-bit-config" {
   type = string
 }
@@ -16,6 +20,10 @@ data "local_file" "fluent-bit-config" {
   filename = basename(var.fluent-bit-config)
 }
 
+data "local_file" "prometheus-config" {
+  filename = basename(var.prometheus-config)
+}
+
 resource "helm_release" "fluent-bit" {
   name       = "fluent-bit"
   namespace  = var.namespace
@@ -23,6 +31,14 @@ resource "helm_release" "fluent-bit" {
   repository = "https://fluent.github.io/helm-charts"
   chart      = "fluent-bit"
   values = [data.local_file.fluent-bit-config.content]
+}
+
+resource "helm_release" "prometheus" {
+  name       = "prometheus"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus"
+  namespace  = var.namespace
+  values = [data.local_file.prometheus-config.content]
 }
 
 resource "helm_release" "elasticsearch" {

--- a/integration/tests/elasticsearch/templates/values/prometheus.yaml
+++ b/integration/tests/elasticsearch/templates/values/prometheus.yaml
@@ -1,0 +1,33 @@
+rbac:
+  create: false
+alertmanager:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+pushgateway:
+  enabled: false
+server:
+  enabled: true
+  global:
+    scrape_interval: 10s
+    scrape_timeout: 9s
+    external_labels:
+      namespace: {{ namespace }}
+  persistentVolume:
+    enabled: false
+serverFiles:
+  prometheus.yml:
+    remote_write:
+      - url: https://prometheus-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: {{ grafana_username }}
+          password: {{ grafana_password }}
+    scrape_configs:
+      - job_name: 'fluent-bit-prometheus'
+        scheme: http
+        metrics_path: /api/v1/metrics/prometheus
+        static_configs:
+          - targets:
+              - "fluent-bit:2020"

--- a/integration/tests/elasticsearch/test_dummy_input_es_output.go
+++ b/integration/tests/elasticsearch/test_dummy_input_es_output.go
@@ -12,11 +12,8 @@ type Suite struct {
 }
 
 func (suite *Suite) TestDummyInputToElasticSearchOutput() {
-
 	cfg, _ := suite.RenderCfgFromTpl("dummy_input_es_output", "",nil)
-	opts, _ := suite.GetTerraformOpts(map[string]interface{}{
-		"fluent-bit-config": cfg,
-	})
+	opts, _ := suite.GetTerraformOpts(cfg)
 
 	defer terraform.Destroy(suite.T(), opts)
 	terraform.InitAndApply(suite.T(), opts)


### PR DESCRIPTION
This commit adds a new helm install (prometheus-server) for gathering
metrics from the fluent-bit prometheus endpoint.

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>