### PR TITLE
FIX: temporary workaround for warnings when executing against a defau…

### DIFF
--- a/integration/tests/base.go
+++ b/integration/tests/base.go
@@ -160,7 +160,7 @@ func (suite *BaseTestSuite) RunKubectlExec(podName string, cmds ...string) (stri
 	for _, cmd := range cmds {
 		args = append(args, cmd)
 	}
-	output, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+	output, err := exec.Command(args[0], args[1:]...).Output()
 	return strings.TrimSuffix(string(output), "\n"), err
 }
 


### PR DESCRIPTION
…lt container in a pod (this causes checks against the output to fail).

Fun one...

When executing against elasticsearch-master-0 we get this output because RunKubectlExec will default to the only running container in the pod out of the two it contains (there's another one used just for initialization).

`
Defaulted container "elasticsearch" out of: elasticsearch, configure-sysctl (init)
`

This also causes false positives when checking later against the output since using CombinedOutput() taints stdin with stderr.
