### PR TITLE
[WIP] Modular tests

### DIFF
--- a/integration/run_integration_test.go
+++ b/integration/run_integration_test.go
@@ -4,17 +4,12 @@ import (
 	"testing"
 
 	"github.com/calyptia/fluent-bit-ci/integration/tests"
-	"github.com/calyptia/fluent-bit-ci/integration/tests/bigquery"
-	"github.com/calyptia/fluent-bit-ci/integration/tests/elasticsearch"
-	"github.com/calyptia/fluent-bit-ci/integration/tests/splunk"
-
-	"github.com/calyptia/fluent-bit-ci/integration/tests/stackdriver"
+	_ "github.com/calyptia/fluent-bit-ci/integration/tests/stdout"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestFluentBitSuites(t *testing.T) {
-	suite.Run(t, &elasticsearch.Suite{BaseTestSuite: tests.BaseTestSuite{Name: "elasticsearch"}})
-	suite.Run(t, &splunk.Suite{BaseTestSuite: tests.BaseTestSuite{Name: "splunk"}})
-	suite.Run(t, &bigquery.Suite{BaseTestSuite: tests.BaseTestSuite{Name: "bigquery"}})
-	suite.Run(t, &stackdriver.Suite{BaseTestSuite: tests.BaseTestSuite{Name: "stackdriver"}})
+	for _, s := range tests.GetSuites() {
+		suite.Run(t, s)
+	}
 }

--- a/integration/tests/base.go
+++ b/integration/tests/base.go
@@ -26,6 +26,21 @@ const defaultK8sImageTag = "x86_64-master"
 const DefaultMaxRetries = 3
 const DefaultRetryTimeout = 1 * time.Minute
 
+var suites []suite.TestingSuite
+
+func init() {
+	suites = make([]suite.TestingSuite, 0)
+}
+
+func AddSuite(s suite.TestingSuite) error {
+	suites = append(suites, s)
+	return nil
+}
+
+func GetSuites() []suite.TestingSuite {
+	return suites
+}
+
 type BaseTestSuite struct {
 	suite.Suite
 	Name, Namespace  string

--- a/integration/tests/stdout/dummy_input_stdout_output.go
+++ b/integration/tests/stdout/dummy_input_stdout_output.go
@@ -1,0 +1,52 @@
+// +build integration
+
+package stdout
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/calyptia/fluent-bit-ci/integration/tests"
+)
+
+type Suite struct {
+	tests.BaseTestSuite
+}
+
+func init() {
+	tests.AddSuite(&Suite{BaseTestSuite: tests.BaseTestSuite{Name: "stdout"}})
+}
+
+func (suite *Suite) TestDummyInputToStdoutOutput() {
+	assert := suite.BaseTestSuite.Assert()
+
+	fluentbitbin, present := os.LookupEnv("FLUENT_BIT_BIN")
+	if present == false {
+		fluentbitbin = "fluent-bit"
+	}
+
+	cmd := exec.Command(fluentbitbin,
+		"-q",
+		"-f", "1",
+		"-i", "dummy",
+		"-o", "stdout",
+		"-p", "match=*",
+		"-o", "exit",
+		"-p", "match=*")
+
+	out, err := cmd.Output()
+	suite.Nil(err)
+
+	lines := strings.Split(string(out), "\n")
+	r := "^\\[\\d+\\] dummy\\.0: \\[\\d+\\.\\d+, \\{\\\"message\\\"\\=\\>\\\"dummy\\\"\\}\\]$"
+	rx := regexp.MustCompile(r)
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		assert.Regexp(rx, line)
+	}
+}

--- a/integration/tests/stdout/dummy_input_stdout_output.go
+++ b/integration/tests/stdout/dummy_input_stdout_output.go
@@ -16,14 +16,16 @@ type Suite struct {
 }
 
 func init() {
-	tests.AddSuite(&Suite{BaseTestSuite: tests.BaseTestSuite{Name: "stdout"}})
+	if err := tests.AddSuite(&Suite{BaseTestSuite: tests.BaseTestSuite{Name: "stdout"}}); err != nil {
+		panic(err)
+	}
 }
 
 func (suite *Suite) TestDummyInputToStdoutOutput() {
 	assert := suite.BaseTestSuite.Assert()
 
 	fluentbitbin, present := os.LookupEnv("FLUENT_BIT_BIN")
-	if present == false {
+	if !present {
 		fluentbitbin = "fluent-bit"
 	}
 


### PR DESCRIPTION
This branch makes the integration test more modular, allowing tests to be enabled and disabled via build tags, etc...

This changes the ABI and inverts the control from the run_integration_test.go file to the actual tests themselves, mostly. It is still necessary to import the tests using underscore syntax but they can now be optionally disabled using build tags.
