### PR TITLE
integration: run all tests.

### DIFF
--- a/integration/tests/bigquery/test_dummy_input_bigquery_output_test.go
+++ b/integration/tests/bigquery/test_dummy_input_bigquery_output_test.go
@@ -9,13 +9,20 @@ import (
 	"github.com/calyptia/fluent-bit-ci/integration/tests"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/iterator"
 	"os"
+	"testing"
 	"time"
 )
 
 type Suite struct {
 	tests.BaseTestSuite
+}
+
+func TestSuite(t *testing.T) {
+	s := &Suite{BaseTestSuite: tests.BaseTestSuite{Name: "bigquery"}}
+	suite.Run(t, s)
 }
 
 func queryBasic(projectID string, tableID string) ([]bq.Value, error) {

--- a/integration/tests/elasticsearch/test_dummy_input_es_output_test.go
+++ b/integration/tests/elasticsearch/test_dummy_input_es_output_test.go
@@ -4,6 +4,9 @@ package elasticsearch
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/suite"
+	"testing"
+
 	"github.com/calyptia/fluent-bit-ci/integration/tests"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -11,6 +14,11 @@ import (
 
 type Suite struct {
 	tests.BaseTestSuite
+}
+
+func TestSuite(t *testing.T) {
+	s := &Suite{BaseTestSuite: tests.BaseTestSuite{Name: "elasticsearch"}}
+	suite.Run(t, s)
 }
 
 func (suite *Suite) TestDummyInputToElasticSearchOutput() {

--- a/integration/tests/splunk/test_dummy_input_splunk_output_test.go
+++ b/integration/tests/splunk/test_dummy_input_splunk_output_test.go
@@ -4,6 +4,9 @@ package splunk
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/suite"
+	"testing"
+
 	"github.com/calyptia/fluent-bit-ci/integration/tests"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -14,6 +17,11 @@ import (
 
 type Suite struct {
 	tests.BaseTestSuite
+}
+
+func TestSuite(t *testing.T) {
+	s := &Suite{BaseTestSuite: tests.BaseTestSuite{Name: "splunk"}}
+	suite.Run(t, s)
 }
 
 func (suite *Suite) TestDummyInputToSplunkOutput() {


### PR DESCRIPTION
The previous commit didn't add all the integration tests to the suite. This patch adds suite.run() to all of them.

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>