### PR TITLE
tests: remove empty filter

### DIFF
--- a/integration/tests/stackdriver/templates/values/dummy_input_stackdriver_output.yaml
+++ b/integration/tests/stackdriver/templates/values/dummy_input_stackdriver_output.yaml
@@ -33,8 +33,6 @@ config:
         Tag {{ logid }}
         Dummy {"message": "testing"}
         Rate 10
-  filters: |
-    [FILTER]
   outputs: |
     [OUTPUT]
         Name stackdriver


### PR DESCRIPTION
The empty filter block triggers an error

Signed-off-by: Patrick Stephens <pat@calyptia.com>